### PR TITLE
Add minimal core framework classes

### DIFF
--- a/app/core/Auth.php
+++ b/app/core/Auth.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Core;
+
+/**
+ * Very small auth facade returning current user id from session.
+ */
+class Auth
+{
+    public static function id(): ?int
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        return isset($_SESSION['user_id']) ? (int)$_SESSION['user_id'] : null;
+    }
+}

--- a/app/core/DB.php
+++ b/app/core/DB.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Core;
+
+use PDO;
+use PDOException;
+
+/**
+ * Simple PDO wrapper with lazy connection loaded from app/config/.env.
+ */
+class DB
+{
+    private static ?PDO $pdo = null;
+
+    /** Obtain shared PDO connection. */
+    public static function connection(): PDO
+    {
+        if (self::$pdo === null) {
+            $envPath = __DIR__ . '/../config/.env';
+            if (!file_exists($envPath)) {
+                throw new PDOException('.env file not found at ' . $envPath);
+            }
+            $env = parse_ini_file($envPath, false, INI_SCANNER_RAW);
+            $driver = $env['DB_CONNECTION'] ?? 'mysql';
+            $host   = $env['DB_HOST'] ?? '127.0.0.1';
+            $port   = $env['DB_PORT'] ?? '3306';
+            $db     = $env['DB_DATABASE'] ?? '';
+            $user   = $env['DB_USERNAME'] ?? '';
+            $pass   = $env['DB_PASSWORD'] ?? '';
+            $dsn = sprintf('%s:host=%s;port=%s;dbname=%s;charset=utf8mb4',
+                $driver,
+                $host,
+                $port,
+                $db
+            );
+            self::$pdo = new PDO($dsn, $user, $pass, [
+                PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ]);
+        }
+        return self::$pdo;
+    }
+
+    public static function beginTransaction(): void
+    {
+        self::connection()->beginTransaction();
+    }
+
+    public static function commit(): void
+    {
+        self::connection()->commit();
+    }
+
+    public static function rollBack(): void
+    {
+        self::connection()->rollBack();
+    }
+
+    public static function query(string $sql, array $params = []): DBResult
+    {
+        $stmt = self::connection()->prepare($sql);
+        $stmt->execute($params);
+        return new DBResult($stmt);
+    }
+}
+
+/**
+ * Lightweight query result wrapper for convenience.
+ */
+class DBResult
+{
+    public function __construct(private \PDOStatement $stmt)
+    {
+    }
+
+    public function all(): array
+    {
+        return $this->stmt->fetchAll();
+    }
+
+    public function first(): array|false
+    {
+        $row = $this->stmt->fetch();
+        return $row === false ? false : $row;
+    }
+}

--- a/app/core/Model.php
+++ b/app/core/Model.php
@@ -1,0 +1,177 @@
+<?php
+declare(strict_types=1);
+
+namespace Core;
+
+use Exception;
+
+/**
+ * Very small ActiveRecord-style base model using PDO.
+ */
+abstract class Model
+{
+    protected string $table;
+    protected array $fillable = [];
+    protected array $attributes = [];
+
+    public function __construct(array $attrs = [])
+    {
+        foreach ($attrs as $k => $v) {
+            if (in_array($k, $this->fillable, true) || $k === 'id') {
+                $this->attributes[$k] = $v;
+            }
+        }
+    }
+
+    public function __get(string $key)
+    {
+        return $this->attributes[$key] ?? null;
+    }
+
+    public function __set(string $key, $value): void
+    {
+        if (in_array($key, $this->fillable, true) || $key === 'id') {
+            $this->attributes[$key] = $value;
+        }
+    }
+
+    public function save(): void
+    {
+        $cols = array_keys($this->attributes);
+        if (isset($this->attributes['id'])) {
+            $set = [];
+            $params = [];
+            foreach ($cols as $c) {
+                if ($c === 'id') continue;
+                $set[] = "$c=?";
+                $params[] = $this->attributes[$c];
+            }
+            $params[] = $this->attributes['id'];
+            $sql = "UPDATE {$this->table} SET " . implode(',', $set) . " WHERE id=?";
+            DB::query($sql, $params);
+        } else {
+            $placeholders = implode(',', array_fill(0, count($cols), '?'));
+            $sql = "INSERT INTO {$this->table} (" . implode(',', $cols) . ") VALUES ({$placeholders})";
+            DB::query($sql, array_map(fn($c) => $this->attributes[$c], $cols));
+            $this->attributes['id'] = (int)DB::connection()->lastInsertId();
+        }
+    }
+
+    // ----- Query builder -----
+    public static function query(): QueryBuilder
+    {
+        $inst = new static();
+        return new QueryBuilder($inst->table, static::class);
+    }
+
+    public static function where(string $column, $operatorOrValue, $value = null): QueryBuilder
+    {
+        return static::query()->where($column, $operatorOrValue, $value);
+    }
+
+    public static function whereRaw(string $expr, array $params = []): QueryBuilder
+    {
+        return static::query()->whereRaw($expr, $params);
+    }
+
+    public static function orderBy(string $column, string $dir = 'asc'): QueryBuilder
+    {
+        return static::query()->orderBy($column, $dir);
+    }
+
+    public static function findOrFail(int $id): static
+    {
+        $inst = new static();
+        $row = DB::query("SELECT * FROM {$inst->table} WHERE id=? LIMIT 1", [$id])->first();
+        if (!$row) {
+            throw new Exception('Record not found');
+        }
+        $model = new static($row);
+        $model->attributes['id'] = (int)$row['id'];
+        return $model;
+    }
+}
+
+class QueryBuilder
+{
+    private string $table;
+    private string $modelClass;
+    private array $wheres = [];
+    private array $params = [];
+    private array $order = [];
+    private ?int $limit = null;
+    private bool $forUpdate = false;
+
+    public function __construct(string $table, string $modelClass)
+    {
+        $this->table = $table;
+        $this->modelClass = $modelClass;
+    }
+
+    public function where(string $column, $operatorOrValue, $value = null): self
+    {
+        if ($value === null) {
+            $value = $operatorOrValue;
+            $operator = '=';
+        } else {
+            $operator = $operatorOrValue;
+        }
+        $this->wheres[] = "$column $operator ?";
+        $this->params[] = $value;
+        return $this;
+    }
+
+    public function whereRaw(string $expr, array $params = []): self
+    {
+        $this->wheres[] = $expr;
+        $this->params = array_merge($this->params, $params);
+        return $this;
+    }
+
+    public function orderBy(string $column, string $dir = 'asc'): self
+    {
+        $this->order[] = "$column " . strtoupper($dir);
+        return $this;
+    }
+
+    public function limit(int $limit): self
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    public function lockForUpdate(): self
+    {
+        $this->forUpdate = true;
+        return $this;
+    }
+
+    public function get(): array
+    {
+        $sql = "SELECT * FROM {$this->table}";
+        if ($this->wheres) {
+            $sql .= ' WHERE ' . implode(' AND ', $this->wheres);
+        }
+        if ($this->order) {
+            $sql .= ' ORDER BY ' . implode(', ', $this->order);
+        }
+        if ($this->limit !== null) {
+            $sql .= ' LIMIT ' . $this->limit;
+        }
+        if ($this->forUpdate) {
+            $sql .= ' FOR UPDATE';
+        }
+        $rows = DB::query($sql, $this->params)->all();
+        return array_map(function ($row) {
+            $model = new $this->modelClass($row);
+            $model->attributes['id'] = (int)($row['id'] ?? 0);
+            return $model;
+        }, $rows);
+    }
+
+    public function paginate(int $perPage): array
+    {
+        $this->limit($perPage);
+        return $this->get();
+    }
+}

--- a/app/core/Request.php
+++ b/app/core/Request.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Core;
+
+/**
+ * Simplified request helper.
+ */
+class Request
+{
+    public static function input(string $key, $default = null)
+    {
+        return $_POST[$key] ?? $_GET[$key] ?? $default;
+    }
+
+    public static function only(array $keys): array
+    {
+        $data = [];
+        foreach ($keys as $k) {
+            if (isset($_POST[$k])) {
+                $data[$k] = $_POST[$k];
+            }
+        }
+        return $data;
+    }
+}

--- a/app/core/Response.php
+++ b/app/core/Response.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Core;
+
+/**
+ * Minimal response helper for redirects and flash messages.
+ */
+class Response
+{
+    public static function redirect(string $url): self
+    {
+        header('Location: ' . $url);
+        return new self();
+    }
+
+    public function with(string $key, string $value): self
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION[$key] = $value;
+        return $this;
+    }
+}

--- a/app/models/InkBatch.php
+++ b/app/models/InkBatch.php
@@ -1,8 +1,10 @@
 <?php
 namespace App\Models;
 
+use Core\Model;
+
 class InkBatch extends Model
 {
-    protected $table = 'ink_batches';
-    protected $fillable = ['item_id','batch_no','supplier','expiry_date','unit_cost','qty_received','qty_remaining','received_at','remarks'];
+    protected string $table = 'ink_batches';
+    protected array $fillable = ['item_id','batch_no','supplier','expiry_date','unit_cost','qty_received','qty_remaining','received_at','remarks'];
 }

--- a/app/models/InkItem.php
+++ b/app/models/InkItem.php
@@ -2,11 +2,12 @@
 namespace App\Models;
 
 use Core\DB;
+use Core\Model;
 
 class InkItem extends Model
 {
-    protected $table = 'ink_items';
-    protected $fillable = ['sku','name','brand','color','printer_models','uom','reorder_point','is_active'];
+    protected string $table = 'ink_items';
+    protected array $fillable = ['sku','name','brand','color','printer_models','uom','reorder_point','is_active'];
 
     public function batches() {
         return InkBatch::where('item_id', $this->id)->orderBy('received_at','asc')->get();

--- a/app/models/InkMovement.php
+++ b/app/models/InkMovement.php
@@ -1,8 +1,10 @@
 <?php
 namespace App\Models;
 
+use Core\Model;
+
 class InkMovement extends Model
 {
-    protected $table = 'ink_movements';
-    protected $fillable = ['item_id','batch_id','txn_date','type','ref_no','doc_type','doc_id','location','qty','unit_cost','avg_cost','note','created_by'];
+    protected string $table = 'ink_movements';
+    protected array $fillable = ['item_id','batch_id','txn_date','type','ref_no','doc_type','doc_id','location','qty','unit_cost','avg_cost','note','created_by'];
 }


### PR DESCRIPTION
## Summary
- add lightweight PDO database wrapper and ActiveRecord-style model base
- provide basic Request, Response, and Auth helpers
- type-hint model properties and import core Model class

## Testing
- `php tests/DatabaseConnectionTest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68af1366657c832eb86d0c743184b86b